### PR TITLE
Only send known settings to device

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ appSettings.initialize(
 ```
 Note : initialize is a generic method. It allows this module to preserve your own type for settings. It will make your work easier with Visauls Studio Code and Typescript.
 
+Node : only known settings (those defined in `Settings`) will be delivered to the device.
+
 ### 4. Initilize the companion app
 Inside the `companion` folder the `index.ts` file have to :
 - Import the setting module.

--- a/Sources/companion/index.ts
+++ b/Sources/companion/index.ts
@@ -9,7 +9,8 @@ import { MessageData } from "../common";
 export function initialize<T>(defaultSettings: T): void {
   // Whensettings changed -> send the new value
   settingsStorage.onchange = (e) => {
-    if (e.key !== null && e.oldValue !== e.newValue && e.newValue !== undefined) {
+    if (e.key !== null && e.key in defaultSettings
+         && e.oldValue !== e.newValue && e.newValue !== undefined) {
       sendValue(e.key, e.newValue);
     }
   };


### PR DESCRIPTION
I had to manage settings in a more complex way - following this type of logic.

https://community.fitbit.com/t5/SDK-Development/Handling-complex-object-with-AdditiveList/m-p/4292620#M12270

This ensures that only known `Settings` values are passed to the peer device.